### PR TITLE
Add monitor translations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-/.idea/
+*/.idea/
 *.iml

--- a/monitor-translations/disk/create-mounts-list.json
+++ b/monitor-translations/disk/create-mounts-list.json
@@ -1,0 +1,11 @@
+{
+  "agentType": "TELEGRAF",
+  "monitorType": "disk",
+  "name": "create-mounts-list",
+  "description": "Converts a single value to the list required by telegraf",
+  "translatorSpec": {
+    "type": "scalarToArray",
+    "from": "mount",
+    "to": "mountPoints"
+  }
+}

--- a/monitor-translations/diskio/create-devices-list.json
+++ b/monitor-translations/diskio/create-devices-list.json
@@ -1,0 +1,11 @@
+{
+  "agentType": "TELEGRAF",
+  "monitorType": "diskio",
+  "name": "create-devices-list",
+  "description": "Converts a single value to the list required by telegraf",
+  "translatorSpec": {
+    "type": "scalarToArray",
+    "from": "device",
+    "to": "devices"
+  }
+}

--- a/monitor-translations/dns/create-domain-list.json
+++ b/monitor-translations/dns/create-domain-list.json
@@ -1,0 +1,11 @@
+{
+  "agentType": "TELEGRAF",
+  "monitorType": "dns",
+  "name": "create-domain-list",
+  "description": "Converts a single value to the list required by telegraf",
+  "translatorSpec": {
+    "type": "scalarToArray",
+    "from": "domain",
+    "to": "domains"
+  }
+}

--- a/monitor-translations/dns/create-server-list.json
+++ b/monitor-translations/dns/create-server-list.json
@@ -1,0 +1,11 @@
+{
+  "agentType": "TELEGRAF",
+  "monitorType": "dns",
+  "name": "create-server-list",
+  "description": "Converts a single value to the list required by telegraf",
+  "translatorSpec": {
+    "type": "scalarToArray",
+    "from": "dnsServer",
+    "to": "servers"
+  }
+}

--- a/monitor-translations/dns/rename-type.json
+++ b/monitor-translations/dns/rename-type.json
@@ -1,0 +1,11 @@
+{
+  "agentType": "TELEGRAF",
+  "monitorType": "dns",
+  "name": "rename-type",
+  "description": "The telegraf input plugin is named dns_query",
+  "translatorSpec": {
+    "type": "replaceStringFieldValue",
+    "field": "type",
+    "value": "dns_query"
+  }
+}

--- a/monitor-translations/dns/rename-type.json
+++ b/monitor-translations/dns/rename-type.json
@@ -4,8 +4,7 @@
   "name": "rename-type",
   "description": "The telegraf input plugin is named dns_query",
   "translatorSpec": {
-    "type": "replaceStringFieldValue",
-    "field": "type",
+    "type": "renameType",
     "value": "dns_query"
   }
 }

--- a/monitor-translations/http/rename-type.json
+++ b/monitor-translations/http/rename-type.json
@@ -4,8 +4,7 @@
   "name": "rename-type",
   "description": "The telegraf input plugin is named http_response",
   "translatorSpec": {
-    "type": "replaceStringFieldValue",
-    "field": "type",
+    "type": "renameType",
     "value": "http_response"
   }
 }

--- a/monitor-translations/http/rename-type.json
+++ b/monitor-translations/http/rename-type.json
@@ -1,0 +1,11 @@
+{
+  "agentType": "TELEGRAF",
+  "monitorType": "http",
+  "name": "rename-type",
+  "description": "The telegraf input plugin is named http_response",
+  "translatorSpec": {
+    "type": "replaceStringFieldValue",
+    "field": "type",
+    "value": "http_response"
+  }
+}

--- a/monitor-translations/mysql/add-metric-version.json
+++ b/monitor-translations/mysql/add-metric-version.json
@@ -1,0 +1,11 @@
+{
+  "agentType": "TELEGRAF",
+  "monitorType": "mysql",
+  "name": "add-metric-version",
+  "description": "This field is required to use the v2 version of the plugin's collection queries",
+  "translatorSpec": {
+    "type": "replaceIntFieldValue",
+    "field": "metric_version",
+    "value": 2
+  }
+}

--- a/monitor-translations/net/create-interface-list.json
+++ b/monitor-translations/net/create-interface-list.json
@@ -1,0 +1,11 @@
+{
+  "agentType": "TELEGRAF",
+  "monitorType": "net",
+  "name": "create-interface-list",
+  "description": "Converts a single value to the list required by telegraf",
+  "translatorSpec": {
+    "type": "scalarToArray",
+    "from": "interface",
+    "to": "interfaces"
+  }
+}

--- a/monitor-translations/net_response/join-host-port.json
+++ b/monitor-translations/net_response/join-host-port.json
@@ -1,0 +1,11 @@
+{
+  "agentType": "TELEGRAF",
+  "monitorType": "net_response",
+  "name": "join-host-port",
+  "description": "Combines the individual host and port fields into a single address",
+  "translatorSpec": {
+    "fromHost": "host",
+    "fromPort": "port",
+    "to": "address"
+  }
+}

--- a/monitor-translations/net_response/join-host-port.json
+++ b/monitor-translations/net_response/join-host-port.json
@@ -4,6 +4,7 @@
   "name": "join-host-port",
   "description": "Combines the individual host and port fields into a single address",
   "translatorSpec": {
+    "type": "joinHostPort",
     "fromHost": "host",
     "fromPort": "port",
     "to": "address"

--- a/monitor-translations/ping/create-url-list.json
+++ b/monitor-translations/ping/create-url-list.json
@@ -1,0 +1,11 @@
+{
+  "agentType": "TELEGRAF",
+  "monitorType": "ping",
+  "name": "create-url-list",
+  "description": "Converts a single value to the list required by telegraf",
+  "translatorSpec": {
+    "type": "scalarToArray",
+    "from": "target",
+    "to": "urls"
+  }
+}

--- a/monitor-translations/sqlserver/add-query-version.json
+++ b/monitor-translations/sqlserver/add-query-version.json
@@ -1,0 +1,11 @@
+{
+  "agentType": "TELEGRAF",
+  "monitorType": "sqlserver",
+  "name": "add-query-version",
+  "description": "This field is required to use the v2 version of the plugin's collection queries",
+  "translatorSpec": {
+    "type": "replaceIntFieldValue",
+    "field": "query_version",
+    "value": 2
+  }
+}

--- a/monitor-translations/sqlserver/rename-exclusion-query.json
+++ b/monitor-translations/sqlserver/rename-exclusion-query.json
@@ -1,0 +1,11 @@
+{
+  "agentType": "TELEGRAF",
+  "monitorType": "sqlserver",
+  "name": "rename-query-exclusions",
+  "description": "Jackson excludes fields that are camelCase and start with the word exclude. This allows us to bypass that without making configuration changes that affect all other jackson interactions.",
+  "translatorSpec": {
+    "type": "renameFieldKey",
+    "from": "queryExclusions",
+    "to": "exclude_queries"
+  }
+}

--- a/monitor-translations/ssl/create-source-list.json
+++ b/monitor-translations/ssl/create-source-list.json
@@ -1,0 +1,11 @@
+{
+  "agentType": "TELEGRAF",
+  "monitorType": "ssl",
+  "name": "create-source-list",
+  "description": "Converts a single value to the list required by telegraf",
+  "translatorSpec": {
+    "type": "scalarToArray",
+    "from": "target",
+    "to": "sources"
+  }
+}

--- a/monitor-translations/ssl/rename-type.json
+++ b/monitor-translations/ssl/rename-type.json
@@ -4,8 +4,7 @@
   "name": "rename-type",
   "description": "The telegraf input plugin is named x509_cert",
   "translatorSpec": {
-    "type": "replaceStringFieldValue",
-    "field": "type",
+    "type": "renameType",
     "value": "x509_cert"
   }
 }

--- a/monitor-translations/ssl/rename-type.json
+++ b/monitor-translations/ssl/rename-type.json
@@ -1,0 +1,11 @@
+{
+  "agentType": "TELEGRAF",
+  "monitorType": "ssl",
+  "name": "rename-type",
+  "description": "The telegraf input plugin is named x509_cert",
+  "translatorSpec": {
+    "type": "replaceStringFieldValue",
+    "field": "type",
+    "value": "x509_cert"
+  }
+}


### PR DESCRIPTION
Adds various monitor translations.  The corresponding plugin POJOs in MonitorManagement will be modified to reflect these.  These allow us to translate the monitor payload provided by the customer to the format that telegraf expects.

## Disk
 * Accept a `mount` string and convert it to a singleton list of `mounts`

## DiskIO
 * Accept a `device` string and convert it to a singleton list of `devices`

This monitor type might need to be reviewed a little more, but this should be a safe first change.

## DNS
 * Accept a `domain` string and convert it to a singleton list of `domains`
 * Accept a `dnsServer` string and convert it to a singleton list of `servers`
 * Rename the type field from `dns` to `dns_query`

## HTTP
 * Rename the type field from `http` to `http_response`

## MySQL
 * Input the `metric_version` field into the monitor config

## Net
 * Accept an `interface` string and convert it to a singleton list of `interfaces`

## Ping
 * Accept a `target` string and convert it to a singleton list of `urls`

## SQLServer
 * Input the `query_version` field into the monitor config
 * Rename the `queryExclusions` field to `exclude_queries`

## SSL
 * Accept a `target` string and convert it to a singleton list of `sources`
 * Rename the type field from `ssl` to `x509_cert`