### PR TITLE
Add urls translator for http monitors

### DIFF
--- a/monitor-translations/http/create-urls-list.json
+++ b/monitor-translations/http/create-urls-list.json
@@ -1,0 +1,11 @@
+{
+  "agentType": "TELEGRAF",
+  "monitorType": "http",
+  "name": "create-urls-list",
+  "description": "Converts a single value to the list required by telegraf",
+  "translatorSpec": {
+    "type": "scalarToArray",
+    "from": "url",
+    "to": "urls"
+  }
+}


### PR DESCRIPTION
Telegraf now expects a list of urls.  This converts the `url` field in the `http` monitor to be a singleton list of `urls`.