### PR TITLE
Add http timeout translation

### DIFF
--- a/monitor-translations/http/rename-exclusion-query.json
+++ b/monitor-translations/http/rename-exclusion-query.json
@@ -1,7 +1,7 @@
 {
   "agentType": "TELEGRAF",
   "monitorType": "http",
-  "name": "rename-timeout",
+  "name": "http-rename-timeout",
   "description": "We use timeout to make things consistent across monitor types",
   "translatorSpec": {
     "type": "renameFieldKey",

--- a/monitor-translations/http/rename-exclusion-query.json
+++ b/monitor-translations/http/rename-exclusion-query.json
@@ -1,0 +1,11 @@
+{
+  "agentType": "TELEGRAF",
+  "monitorType": "http",
+  "name": "rename-timeout",
+  "description": "We use timeout to make things consistent across monitor types",
+  "translatorSpec": {
+    "type": "renameFieldKey",
+    "from": "timeout",
+    "to": "responseTimeout"
+  }
+}


### PR DESCRIPTION
Use `timeout` in the model the customer sees to keep things more standardized.