### PR TITLE
Add redis translation

### DIFF
--- a/monitor-translations/redis/create-servers-list.json
+++ b/monitor-translations/redis/create-servers-list.json
@@ -1,0 +1,11 @@
+{
+  "agentType": "TELEGRAF",
+  "monitorType": "redis",
+  "name": "create-servers-list",
+  "description": "Converts a single value to the list required by telegraf",
+  "translatorSpec": {
+    "type": "scalarToArray",
+    "from": "url",
+    "to": "servers"
+  }
+}


### PR DESCRIPTION
Goes with https://github.com/racker/salus-telemetry-monitor-management/pull/136/files

Adds a translation to change the `url` field to become `servers` as required by https://github.com/influxdata/telegraf/tree/master/plugins/inputs/redis