### PR TITLE
Added initial packages agent

### DIFF
--- a/agent-releases/packages-agent/0.1.0-darwin.json
+++ b/agent-releases/packages-agent/0.1.0-darwin.json
@@ -1,0 +1,10 @@
+{
+  "type": "PACKAGES",
+  "exe": "salus-packages-agent",
+  "labels": {
+    "agent_discovered_arch": "amd64",
+    "agent_discovered_os": "darwin"
+  },
+  "version": "0.1.0",
+  "url": "https://github.com/racker/salus-packages-agent/releases/download/v0.1.0/salus-packages-agent_0.1.0_Darwin_x86_64.tar.gz"
+}

--- a/agent-releases/packages-agent/0.1.0-linux-amd64.json
+++ b/agent-releases/packages-agent/0.1.0-linux-amd64.json
@@ -1,0 +1,10 @@
+{
+  "type": "PACKAGES",
+  "exe": "salus-packages-agent",
+  "labels": {
+    "agent_discovered_arch": "amd64",
+    "agent_discovered_os": "linux"
+  },
+  "version": "0.1.0",
+  "url": "https://github.com/racker/salus-packages-agent/releases/download/v0.1.0/salus-packages-agent_0.1.0_Linux_x86_64.tar.gz"
+}


### PR DESCRIPTION
For https://jira.rax.io/browse/SALUS-594 this adds the initial version of packages agent to be registered in the agent catalog.