### PR TITLE
Add duration field translations

### DIFF
--- a/monitor-translations/apache/create-urls-list.json
+++ b/monitor-translations/apache/create-urls-list.json
@@ -1,7 +1,7 @@
 {
   "agentType": "TELEGRAF",
   "monitorType": "apache",
-  "name": "apache-create-urls-list",
+  "name": "create-urls-list",
   "description": "Converts a single value to the list required by telegraf",
   "translatorSpec": {
     "type": "scalarToArray",

--- a/monitor-translations/apache/go-timeout.json
+++ b/monitor-translations/apache/go-timeout.json
@@ -1,0 +1,10 @@
+{
+  "agentType": "TELEGRAF",
+  "monitorType": "apache",
+  "name": "go-timeout-value",
+  "description": "Convert from java duration string to a valid Go format for timestamp",
+  "translatorSpec": {
+    "type": "goDuration",
+    "field": "timeout"
+  }
+}

--- a/monitor-translations/apache/rename-timeout.json
+++ b/monitor-translations/apache/rename-timeout.json
@@ -1,7 +1,7 @@
 {
   "agentType": "TELEGRAF",
   "monitorType": "apache",
-  "name": "apache-rename-timeout",
+  "name": "rename-timeout",
   "description": "We use timeout to make things consistent across monitor types",
   "translatorSpec": {
     "type": "renameFieldKey",

--- a/monitor-translations/dns/timeout-in-seconds.json
+++ b/monitor-translations/dns/timeout-in-seconds.json
@@ -1,0 +1,10 @@
+{
+  "agentType": "TELEGRAF",
+  "monitorType": "dns",
+  "name": "timeout-in-seconds",
+  "description": "Convert from java duration string to raw seconds",
+  "translatorSpec": {
+    "type": "durationInSeconds",
+    "field": "timeout"
+  }
+}

--- a/monitor-translations/http/go-timeout.json
+++ b/monitor-translations/http/go-timeout.json
@@ -1,0 +1,10 @@
+{
+  "agentType": "TELEGRAF",
+  "monitorType": "http",
+  "name": "go-timeout-value",
+  "description": "Convert from java duration string to a valid Go format for timestamp",
+  "translatorSpec": {
+    "type": "goDuration",
+    "field": "timeout"
+  }
+}

--- a/monitor-translations/http/rename-exclusion-query.json
+++ b/monitor-translations/http/rename-exclusion-query.json
@@ -1,7 +1,7 @@
 {
   "agentType": "TELEGRAF",
   "monitorType": "http",
-  "name": "http-rename-timeout",
+  "name": "rename-timeout",
   "description": "We use timeout to make things consistent across monitor types",
   "translatorSpec": {
     "type": "renameFieldKey",

--- a/monitor-translations/mysql/go-timeout.json
+++ b/monitor-translations/mysql/go-timeout.json
@@ -1,0 +1,10 @@
+{
+  "agentType": "TELEGRAF",
+  "monitorType": "mysql",
+  "name": "go-timeout-value",
+  "description": "Convert from java duration string to a valid Go format for timestamp",
+  "translatorSpec": {
+    "type": "goDuration",
+    "field": "intervalSlow"
+  }
+}

--- a/monitor-translations/net_response/go-read-timeout.json
+++ b/monitor-translations/net_response/go-read-timeout.json
@@ -1,0 +1,10 @@
+{
+  "agentType": "TELEGRAF",
+  "monitorType": "net_response",
+  "name": "go-read-timeout-value",
+  "description": "Convert from java duration string to a valid Go format for timestamp",
+  "translatorSpec": {
+    "type": "goDuration",
+    "field": "readTimeout"
+  }
+}

--- a/monitor-translations/net_response/go-timeout.json
+++ b/monitor-translations/net_response/go-timeout.json
@@ -1,0 +1,10 @@
+{
+  "agentType": "TELEGRAF",
+  "monitorType": "net_response",
+  "name": "go-timeout-value",
+  "description": "Convert from java duration string to a valid Go format for timestamp",
+  "translatorSpec": {
+    "type": "goDuration",
+    "field": "timeout"
+  }
+}

--- a/monitor-translations/ping/deadline-in-seconds.json
+++ b/monitor-translations/ping/deadline-in-seconds.json
@@ -1,0 +1,10 @@
+{
+  "agentType": "TELEGRAF",
+  "monitorType": "ping",
+  "name": "deadline-in-seconds",
+  "description": "Convert from java duration string to raw seconds",
+  "translatorSpec": {
+    "type": "durationInSeconds",
+    "field": "deadline"
+  }
+}

--- a/monitor-translations/ping/ping-interval-in-seconds.json
+++ b/monitor-translations/ping/ping-interval-in-seconds.json
@@ -1,0 +1,10 @@
+{
+  "agentType": "TELEGRAF",
+  "monitorType": "ping",
+  "name": "ping-interval-in-seconds",
+  "description": "Convert from java duration string to raw seconds",
+  "translatorSpec": {
+    "type": "durationInSeconds",
+    "field": "pingInterval"
+  }
+}

--- a/monitor-translations/ping/timeout-in-seconds.json
+++ b/monitor-translations/ping/timeout-in-seconds.json
@@ -1,0 +1,10 @@
+{
+  "agentType": "TELEGRAF",
+  "monitorType": "ping",
+  "name": "timeout-in-seconds",
+  "description": "Convert from java duration string to raw seconds",
+  "translatorSpec": {
+    "type": "durationInSeconds",
+    "field": "timeout"
+  }
+}

--- a/monitor-translations/postgresql/go-timeout.json
+++ b/monitor-translations/postgresql/go-timeout.json
@@ -1,0 +1,10 @@
+{
+  "agentType": "TELEGRAF",
+  "monitorType": "postgresql",
+  "name": "go-max-lifetime-value",
+  "description": "Convert from java duration string to a valid Go format for timestamp",
+  "translatorSpec": {
+    "type": "goDuration",
+    "field": "maxLifetime"
+  }
+}

--- a/monitor-translations/ssl/go-timeout.json
+++ b/monitor-translations/ssl/go-timeout.json
@@ -1,0 +1,10 @@
+{
+  "agentType": "TELEGRAF",
+  "monitorType": "ssl",
+  "name": "go-timeout-value",
+  "description": "Convert from java duration string to a valid Go format for timestamp",
+  "translatorSpec": {
+    "type": "goDuration",
+    "field": "timeout"
+  }
+}


### PR DESCRIPTION
# What
Translations for all the plugin fields using `Duration`.

Some are converted to seconds and others are converted to the go format.

DurationInSecondsTranslator - https://github.com/racker/salus-telemetry-model/pull/107
GoDurationTranslator - https://github.com/racker/salus-telemetry-model/pull/106

I also removed the check type prefixes from some of the names that were added in a previous PR since they are not needed and this makes them consistent with everything else.