### PR TITLE
Added telegraf 1.13.2

### DIFF
--- a/agent-releases/telegraf/1.13.2-darwin.json
+++ b/agent-releases/telegraf/1.13.2-darwin.json
@@ -5,6 +5,6 @@
     "agent_discovered_arch": "amd64",
     "agent_discovered_os": "darwin"
   },
-  "url": "https://homebrew.bintray.com/bottles/telegraf-1.13.2.high_sierra.bottle.tar.gz",
+  "url": "https://homebrew.bintray.com/bottles/telegraf-1.13.2.mojave.bottle.tar.gz",
   "exe": "telegraf/1.13.2/bin/telegraf"
 }

--- a/agent-releases/telegraf/1.13.2-darwin.json
+++ b/agent-releases/telegraf/1.13.2-darwin.json
@@ -1,0 +1,10 @@
+{
+  "type": "TELEGRAF",
+  "version": "1.13.2",
+  "labels": {
+    "agent_discovered_arch": "amd64",
+    "agent_discovered_os": "darwin"
+  },
+  "url": "https://homebrew.bintray.com/bottles/telegraf-1.13.2.high_sierra.bottle.tar.gz",
+  "exe": "telegraf/1.13.2/bin/telegraf"
+}

--- a/agent-releases/telegraf/1.13.2-linux-amd64.json
+++ b/agent-releases/telegraf/1.13.2-linux-amd64.json
@@ -1,0 +1,10 @@
+{
+  "type": "TELEGRAF",
+  "version": "1.13.2",
+  "labels": {
+    "agent_discovered_arch": "amd64",
+    "agent_discovered_os": "linux"
+  },
+  "url": "https://dl.influxdata.com/telegraf/releases/telegraf-1.13.2-static_linux_amd64.tar.gz",
+  "exe": "./telegraf/telegraf"
+}


### PR DESCRIPTION
Added agent release declaration for telegraf 1.13.2 since we'll treat that as our baseline version for monitor translation compatibility.