### PR TITLE
Add initial monitor metadata policies

### DIFF
--- a/monitor-metadata-policies/apache/timeout.json
+++ b/monitor-metadata-policies/apache/timeout.json
@@ -1,0 +1,9 @@
+{
+  "scope": "GLOBAL",
+  "subscope": null,
+  "targetClassName": "LocalPlugin",
+  "monitorType": "apache",
+  "valueType": "DURATION",
+  "key": "timeout",
+  "value": "PT10S"
+}

--- a/monitor-metadata-policies/default-interval.json
+++ b/monitor-metadata-policies/default-interval.json
@@ -1,0 +1,8 @@
+{
+  "scope": "GLOBAL",
+  "subscope": null,
+  "targetClassName": "Monitor",
+  "valueType": "DURATION",
+  "key": "interval",
+  "value": "PT1M"
+}

--- a/monitor-metadata-policies/http/redirects.json
+++ b/monitor-metadata-policies/http/redirects.json
@@ -1,0 +1,9 @@
+{
+  "scope": "GLOBAL",
+  "subscope": null,
+  "targetClassName": "RemotePlugin",
+  "monitorType": "http",
+  "valueType": "BOOL",
+  "key": "followRedirects",
+  "value": "true"
+}

--- a/monitor-metadata-policies/http/timeout.json
+++ b/monitor-metadata-policies/http/timeout.json
@@ -1,0 +1,9 @@
+{
+  "scope": "GLOBAL",
+  "subscope": null,
+  "targetClassName": "RemotePlugin",
+  "monitorType": "http",
+  "valueType": "DURATION",
+  "key": "timeout",
+  "value": "PT30S"
+}

--- a/monitor-metadata-policies/net_response/timeout.json
+++ b/monitor-metadata-policies/net_response/timeout.json
@@ -1,0 +1,9 @@
+{
+  "scope": "GLOBAL",
+  "subscope": null,
+  "targetClassName": "RemotePlugin",
+  "monitorType": "net_response",
+  "valueType": "DURATION",
+  "key": "timeout",
+  "value": "PT10S"
+}

--- a/monitor-metadata-policies/ping/count.json
+++ b/monitor-metadata-policies/ping/count.json
@@ -1,0 +1,9 @@
+{
+  "scope": "GLOBAL",
+  "subscope": null,
+  "targetClassName": "RemotePlugin",
+  "monitorType": "ping",
+  "valueType": "INT",
+  "key": "count",
+  "value": "5"
+}


### PR DESCRIPTION
Initial metadata policies for monitors.

The most important one is the global `interval` change for all monitors.

Others may change before we go "live"