### PR TITLE
added oracle agent data

### DIFF
--- a/agent-releases/oracle-agent/0.2.0-darwin.json
+++ b/agent-releases/oracle-agent/0.2.0-darwin.json
@@ -1,0 +1,10 @@
+{
+  "type": "ORACLE",
+  "exe": "salus-oracle-agent",
+  "labels": {
+    "agent_discovered_arch": "amd64",
+    "agent_discovered_os": "darwin"
+  },
+  "version": "0.2.0",
+  "url": "https://github.com/racker/salus-oracle-agent/releases/download/0.2.0/salus-oracle-agent_0.2.0_Darwin_x86_64.tar.gz"
+}

--- a/agent-releases/oracle-agent/0.2.0-linux-amd64.json
+++ b/agent-releases/oracle-agent/0.2.0-linux-amd64.json
@@ -1,0 +1,10 @@
+{
+  "type": "ORACLE",
+  "exe": "salus-oracle-agent",
+  "labels": {
+    "agent_discovered_arch": "amd64",
+    "agent_discovered_os": "linux"
+  },
+  "version": "0.2.0",
+  "url": "https://github.com/racker/salus-oracle-agent/releases/download/0.2.0/salus-oracle-agent_0.2.0_Linux_x86_64.tar.gz"
+}


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-819

# What

Makes sure that the oracle-agent is a valid monitoring agent

# How

This PR adds the oracle agent to the data loader config data. So when a new cluster is created it should have the oracle agent already installed.

## How to test

Start everything locally. attach an envoy and see if it installs the oracle agent

