### PR TITLE
Add order to translations where it's required

### DIFF
--- a/monitor-translations/apache/go-timeout.json
+++ b/monitor-translations/apache/go-timeout.json
@@ -6,5 +6,6 @@
   "translatorSpec": {
     "type": "goDuration",
     "field": "timeout"
-  }
+  },
+  "order": 1
 }

--- a/monitor-translations/apache/rename-timeout.json
+++ b/monitor-translations/apache/rename-timeout.json
@@ -7,5 +7,6 @@
     "type": "renameFieldKey",
     "from": "timeout",
     "to": "responseTimeout"
-  }
+  },
+  "order": 2
 }

--- a/monitor-translations/http/go-timeout.json
+++ b/monitor-translations/http/go-timeout.json
@@ -6,5 +6,6 @@
   "translatorSpec": {
     "type": "goDuration",
     "field": "timeout"
-  }
+  },
+  "order": 1
 }

--- a/monitor-translations/http/rename-timeout.json
+++ b/monitor-translations/http/rename-timeout.json
@@ -7,5 +7,6 @@
     "type": "renameFieldKey",
     "from": "timeout",
     "to": "responseTimeout"
-  }
+  },
+  "order": 2
 }


### PR DESCRIPTION
Follows on from https://github.com/racker/salus-telemetry-monitor-management/pull/155/files

These are translations that must be performed in order since they depend on eachother.

In each case the `timeout` field is converted to a go style duration and then the field is renamed to `responseTimeout`.