### PR TITLE
Add smtp translation

### DIFF
--- a/monitor-translations/smtp/join-host-port.json
+++ b/monitor-translations/smtp/join-host-port.json
@@ -1,0 +1,12 @@
+{
+  "agentType": "TELEGRAF",
+  "monitorType": "smtp",
+  "name": "join-host-port",
+  "description": "Combines the individual host and port fields into a single address",
+  "translatorSpec": {
+    "type": "joinHostPort",
+    "fromHost": "host",
+    "fromPort": "port",
+    "to": "address"
+  }
+}


### PR DESCRIPTION
Adds a basic host/port translation for https://github.com/racker/salus-telemetry-monitor-management/pull/156