### PR TITLE
Add default tenant metadata

### DIFF
--- a/tenant-metadata/12345.json
+++ b/tenant-metadata/12345.json
@@ -1,0 +1,7 @@
+{
+  "tenantId": "12345",
+  "accountType": "cloud",
+  "metadata": {
+    "description": "random account for local dev testing"
+  }
+}

--- a/tenant-metadata/510477.json
+++ b/tenant-metadata/510477.json
@@ -1,0 +1,6 @@
+{
+  "tenantId": "510477",
+  "metadata": {
+    "description": "account used in perf tests"
+  }
+}

--- a/tenant-metadata/833544.json
+++ b/tenant-metadata/833544.json
@@ -1,0 +1,6 @@
+{
+  "tenantId": "833544",
+  "metadata": {
+    "description": "glimpseprod - used for intelligence testing"
+  }
+}

--- a/tenant-metadata/aaaaaa.json
+++ b/tenant-metadata/aaaaaa.json
@@ -1,0 +1,6 @@
+{
+  "tenantId": "aaaaaa",
+  "metadata": {
+    "description": "random account for local dev testing"
+  }
+}

--- a/tenant-metadata/hybrid:test.json
+++ b/tenant-metadata/hybrid:test.json
@@ -1,0 +1,7 @@
+{
+  "tenantId": "hybrid:test",
+  "accountType": "dedicated",
+  "metadata": {
+    "description": "random account for local dev testing"
+  }
+}


### PR DESCRIPTION
Adds 5 tenants that are used in localdev / perf tests / dev (intelligence)