### PR TITLE
Add default zone metadata policies

### DIFF
--- a/monitor-metadata-policies/zone-defaults/default.json
+++ b/monitor-metadata-policies/zone-defaults/default.json
@@ -1,0 +1,8 @@
+{
+  "scope": "GLOBAL",
+  "subscope": null,
+  "targetClassName": "RemotePlugin",
+  "valueType": "STRING_LIST",
+  "key": "monitoring_zones_default",
+  "value": "public/us_central_1,public/us_central_2,public/eu_west_1"
+}

--- a/monitor-metadata-policies/zone-defaults/dfw.json
+++ b/monitor-metadata-policies/zone-defaults/dfw.json
@@ -3,6 +3,6 @@
   "subscope": null,
   "targetClassName": "RemotePlugin",
   "valueType": "STRING_LIST",
-  "key": "monitoring_zones_default",
+  "key": "monitoring_zones_dfw",
   "value": "public/us_central_1,public/us_central_2,public/us_east_1"
 }

--- a/monitor-metadata-policies/zone-defaults/dfw.json
+++ b/monitor-metadata-policies/zone-defaults/dfw.json
@@ -1,0 +1,8 @@
+{
+  "scope": "GLOBAL",
+  "subscope": null,
+  "targetClassName": "RemotePlugin",
+  "valueType": "STRING_LIST",
+  "key": "monitoring_zones_default",
+  "value": "public/us_central_1,public/us_central_2,public/us_east_1"
+}

--- a/monitor-metadata-policies/zone-defaults/fra.json
+++ b/monitor-metadata-policies/zone-defaults/fra.json
@@ -1,0 +1,8 @@
+{
+  "scope": "GLOBAL",
+  "subscope": null,
+  "targetClassName": "RemotePlugin",
+  "valueType": "STRING_LIST",
+  "key": "monitoring_zones_fra",
+  "value": "public/eu_west_1,public/eu_west_2,public/us_east_1"
+}

--- a/monitor-metadata-policies/zone-defaults/hkg.json
+++ b/monitor-metadata-policies/zone-defaults/hkg.json
@@ -1,0 +1,8 @@
+{
+  "scope": "GLOBAL",
+  "subscope": null,
+  "targetClassName": "RemotePlugin",
+  "valueType": "STRING_LIST",
+  "key": "monitoring_zones_hkg",
+  "value": "public/australia_east_1,public/asia_east_1,public/us_central_1"
+}

--- a/monitor-metadata-policies/zone-defaults/iad.json
+++ b/monitor-metadata-policies/zone-defaults/iad.json
@@ -1,0 +1,8 @@
+{
+  "scope": "GLOBAL",
+  "subscope": null,
+  "targetClassName": "RemotePlugin",
+  "valueType": "STRING_LIST",
+  "key": "monitoring_zones_iad",
+  "value": "public/us_central_1,public/us_central_2,public/us_east_1"
+}

--- a/monitor-metadata-policies/zone-defaults/lon.json
+++ b/monitor-metadata-policies/zone-defaults/lon.json
@@ -1,0 +1,8 @@
+{
+  "scope": "GLOBAL",
+  "subscope": null,
+  "targetClassName": "RemotePlugin",
+  "valueType": "STRING_LIST",
+  "key": "monitoring_zones_lon",
+  "value": "public/eu_west_1,public/eu_west_2,public/us_east_1"
+}

--- a/monitor-metadata-policies/zone-defaults/ord.json
+++ b/monitor-metadata-policies/zone-defaults/ord.json
@@ -1,0 +1,8 @@
+{
+  "scope": "GLOBAL",
+  "subscope": null,
+  "targetClassName": "RemotePlugin",
+  "valueType": "STRING_LIST",
+  "key": "monitoring_zones_ord",
+  "value": "public/us_central_1,public/us_central_2,public/us_east_1"
+}

--- a/monitor-metadata-policies/zone-defaults/syd.json
+++ b/monitor-metadata-policies/zone-defaults/syd.json
@@ -1,0 +1,8 @@
+{
+  "scope": "GLOBAL",
+  "subscope": null,
+  "targetClassName": "RemotePlugin",
+  "valueType": "STRING_LIST",
+  "key": "monitoring_zones_syd",
+  "value": "public/australia_east_1,public/asia_east_1,public/us_central_1"
+}


### PR DESCRIPTION
I decided to just use the existing loader definitions for monitor metadata policies instead of creating new ones for the "helper" zone metadata endpoints.

This assumes the region of the resources will be `dfw`, `iad`, `syd` etc.  and not `dfw3`, `iad2` etc.

We can change this later if needed.