### PR TITLE
Add cloudMAAS tenant to prod

### DIFF
--- a/tenant-metadata/646398.json
+++ b/tenant-metadata/646398.json
@@ -1,0 +1,6 @@
+{
+  "tenantId": "646398",
+  "metadata": {
+    "description": "cloudMAAS tenant"
+  }
+}


### PR DESCRIPTION
Notice this is against `production` and not `master`.

Required for envoy configuration.