### PR TITLE
Fix default zone keys

### DIFF
--- a/monitor-metadata-policies/zone-defaults/default.json
+++ b/monitor-metadata-policies/zone-defaults/default.json
@@ -3,6 +3,6 @@
   "subscope": null,
   "targetClassName": "RemotePlugin",
   "valueType": "STRING_LIST",
-  "key": "monitoring_zones_default",
+  "key": "monitoring_zone_default",
   "value": "public/us_central_1,public/us_central_2,public/eu_west_1"
 }

--- a/monitor-metadata-policies/zone-defaults/dfw.json
+++ b/monitor-metadata-policies/zone-defaults/dfw.json
@@ -3,6 +3,6 @@
   "subscope": null,
   "targetClassName": "RemotePlugin",
   "valueType": "STRING_LIST",
-  "key": "monitoring_zones_dfw",
+  "key": "monitoring_zone_dfw",
   "value": "public/us_central_1,public/us_central_2,public/us_east_1"
 }

--- a/monitor-metadata-policies/zone-defaults/fra.json
+++ b/monitor-metadata-policies/zone-defaults/fra.json
@@ -3,6 +3,6 @@
   "subscope": null,
   "targetClassName": "RemotePlugin",
   "valueType": "STRING_LIST",
-  "key": "monitoring_zones_fra",
+  "key": "monitoring_zone_fra",
   "value": "public/eu_west_1,public/eu_west_2,public/us_east_1"
 }

--- a/monitor-metadata-policies/zone-defaults/hkg.json
+++ b/monitor-metadata-policies/zone-defaults/hkg.json
@@ -3,6 +3,6 @@
   "subscope": null,
   "targetClassName": "RemotePlugin",
   "valueType": "STRING_LIST",
-  "key": "monitoring_zones_hkg",
+  "key": "monitoring_zone_hkg",
   "value": "public/australia_east_1,public/asia_east_1,public/us_central_1"
 }

--- a/monitor-metadata-policies/zone-defaults/iad.json
+++ b/monitor-metadata-policies/zone-defaults/iad.json
@@ -3,6 +3,6 @@
   "subscope": null,
   "targetClassName": "RemotePlugin",
   "valueType": "STRING_LIST",
-  "key": "monitoring_zones_iad",
+  "key": "monitoring_zone_iad",
   "value": "public/us_central_1,public/us_central_2,public/us_east_1"
 }

--- a/monitor-metadata-policies/zone-defaults/lon.json
+++ b/monitor-metadata-policies/zone-defaults/lon.json
@@ -3,6 +3,6 @@
   "subscope": null,
   "targetClassName": "RemotePlugin",
   "valueType": "STRING_LIST",
-  "key": "monitoring_zones_lon",
+  "key": "monitoring_zone_lon",
   "value": "public/eu_west_1,public/eu_west_2,public/us_east_1"
 }

--- a/monitor-metadata-policies/zone-defaults/ord.json
+++ b/monitor-metadata-policies/zone-defaults/ord.json
@@ -3,6 +3,6 @@
   "subscope": null,
   "targetClassName": "RemotePlugin",
   "valueType": "STRING_LIST",
-  "key": "monitoring_zones_ord",
+  "key": "monitoring_zone_ord",
   "value": "public/us_central_1,public/us_central_2,public/us_east_1"
 }

--- a/monitor-metadata-policies/zone-defaults/syd.json
+++ b/monitor-metadata-policies/zone-defaults/syd.json
@@ -3,6 +3,6 @@
   "subscope": null,
   "targetClassName": "RemotePlugin",
   "valueType": "STRING_LIST",
-  "key": "monitoring_zones_syd",
+  "key": "monitoring_zone_syd",
   "value": "public/australia_east_1,public/asia_east_1,public/us_central_1"
 }


### PR DESCRIPTION
The key should match the same value that policy mgmt uses - https://github.com/racker/salus-telemetry-model/blob/master/src/main/java/com/rackspace/salus/telemetry/entities/MetadataPolicy.java#L37

I think I'll have to manually remove the current incorrect entries via the api in each environment.